### PR TITLE
Feature/handle-inactive-monetisation/OPTRO-209

### DIFF
--- a/bundle.css
+++ b/bundle.css
@@ -6,6 +6,27 @@
   color: white;
   border-radius: 4px;
   padding: 8px; }
+  .license-display.license-display-error {
+    background-color: #007ad5;
+    color: white;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center; }
+    .license-display.license-display-error .information-icon {
+      color: white;
+      width: 1em;
+      height: 1em;
+      border: 2px solid white;
+      border-radius: 50%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 1px;
+      margin-right: 5px; }
+    .license-display.license-display-error a {
+      color: white; }
   .license-display.license-display-pro {
     background-color: #42526E; }
   .license-display.license-display-free {
@@ -19,3 +40,45 @@
       filter: blur(0.4px);
       color: white;
       opacity: 0.8; }
+  .license-display .OUR-simple-loader {
+    font-size: 8px;
+    margin: 5px; }
+
+.OUR-simple-loader {
+  display: flex;
+  flex-direction: row;
+  gap: .75em;
+  justify-content: center; }
+
+@keyframes loadDot {
+  0% {
+    transform: scale(1); }
+  10% {
+    transform: scale(1.1); }
+  20% {
+    transform: scale(1.2); }
+  22.5% {
+    transform: scale(1.4); }
+  25% {
+    transform: scale(1.5); }
+  27.5% {
+    transform: scale(1.4); }
+  30% {
+    transform: scale(1.2); }
+  45% {
+    transform: scale(1.1); }
+  50% {
+    transform: scale(1); } }
+  .OUR-simple-loader .loadDot {
+    height: 1em;
+    width: 1em;
+    border-radius: 50%;
+    background: black;
+    animation-name: loadDot;
+    animation-duration: 1.8s;
+    animation-iteration-count: infinite;
+    animation-timing-function: steps(90); }
+    .OUR-simple-loader .loadDot:nth-child(2n) {
+      animation-delay: .6s; }
+    .OUR-simple-loader .loadDot:nth-child(3n) {
+      animation-delay: 1.2s; }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/optro-cloud/optro-ui-react.git"
   },
   "website": "https://www.optro.cloud",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "license": "MIT",
   "scripts": {
     "prebuild": "rm -rf dist",

--- a/src/components/license-conditional/LicenseConditional.tsx
+++ b/src/components/license-conditional/LicenseConditional.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import useLicense from '../../hooks/useLicense';
 import { LicenseConditionalProps } from '../../types';
 
-const LicenseConditional = (props: LicenseConditionalProps): JSX.Element => {
+const LicenseConditional = (props: LicenseConditionalProps): React.ReactElement => {
   const licenseContext = useLicense();
 
   // If a loading component is provided in props and the context
@@ -10,6 +10,22 @@ const LicenseConditional = (props: LicenseConditionalProps): JSX.Element => {
   // return the loading component
   if (props.loading && licenseContext.loading) {
     return props.loading;
+  }
+
+  // Monetization is marked as inactive
+  // Return a pro version as preference,
+  // unlicensed as fallback, or none
+  if (licenseContext.inactive) {
+    if (props.licensed) {
+      return props.licensed;
+    }
+    if (props.children) {
+      return props.children;
+    }
+    if (props.unlicensed) {
+      return props.unlicensed;
+    }
+    return <></>;
   }
 
   // If a unlicensed component is provided in props and the context

--- a/src/components/license-provider/LicenseProvider.tsx
+++ b/src/components/license-provider/LicenseProvider.tsx
@@ -31,6 +31,7 @@ const LicenseProvider = (props: LicenseProviderProps): JSX.Element => {
 
   const processResults = (result: OptroLicenseResponse) => {
     return {
+      loading: false,
       expired: result.isRegistered && !result.isLicensed,
       licensed: result.isRegistered && result.isLicensed,
     };

--- a/src/components/license-provider/LicenseProvider.tsx
+++ b/src/components/license-provider/LicenseProvider.tsx
@@ -47,9 +47,9 @@ const LicenseProvider = (props: LicenseProviderProps): JSX.Element => {
             newContext = { ...newContext, ...processResults(result) };
             setContext(newContext);
           }).catch((error: any) => {
-          console.error("An error occurred while checking the license:", error);
-          newContext = {...newContext , loading: false, errored: true};
-          setContext(newContext);
+            console.error('An error occurred while checking the license:', error);
+            newContext = { ...newContext, loading: false, errored: true };
+            setContext(newContext);
           });
       } else if (props.licenseType === LicenseTypeBoard) {
         newContext.licenseId = t.getContext().board;
@@ -58,9 +58,9 @@ const LicenseProvider = (props: LicenseProviderProps): JSX.Element => {
             newContext = { ...newContext, ...processResults(result) };
             setContext(newContext);
           }).catch((error: any) => {
-          console.error("An error occurred while checking the license:", error);
-          newContext = {...newContext , loading: false, errored: true};
-          setContext(newContext);
+            console.error('An error occurred while checking the license:', error);
+            newContext = { ...newContext, loading: false, errored: true };
+            setContext(newContext);
           });
       } else {
         throw new Error('Non standard license type provided. Use "board" or "user"');

--- a/src/components/license-provider/LicenseProvider.tsx
+++ b/src/components/license-provider/LicenseProvider.tsx
@@ -16,7 +16,7 @@ const defaultContext: LicenseContext = {
 
 export const ContextedLicense = React.createContext(defaultContext);
 
-const LicenseProvider = (props: LicenseProviderProps): JSX.Element => {
+const LicenseProvider = (props: LicenseProviderProps): React.ReactElement => {
   const tContext = useContext(TrelloContext);
 
   const [context, setContext] = useState<LicenseContext>({
@@ -41,6 +41,19 @@ const LicenseProvider = (props: LicenseProviderProps): JSX.Element => {
     const t: Trello.PowerUp.IFrame | undefined = props.t ?? tContext;
     if (t) {
       let newContext = { ...context };
+
+      // Escape clause if monetization is inactive
+      if (props.apiKey === 'UNSPECIFIED') {
+        setContext({
+          ...newContext,
+          loading: false,
+          expired: false,
+          licensed: true,
+          inactive: true,
+        });
+        return;
+      }
+
       if (props.licenseType === LicenseTypeUser) {
         newContext.licenseId = t.getContext().member;
         props.optroClient.getMemberLicenseStatus(newContext.licenseId)

--- a/src/components/license-status/LicenseStatus.tsx
+++ b/src/components/license-status/LicenseStatus.tsx
@@ -5,7 +5,7 @@ import { LocaleKey, SubscriptionStatusProps } from '../../types';
 import { useLicense } from '../../hooks';
 import './styles.scss';
 
-const LicenseStatus = (props: SubscriptionStatusProps): JSX.Element => {
+const LicenseStatus = (props: SubscriptionStatusProps): React.ReactElement => {
   const locale: LocaleKey = props.locale
     ? props.locale
     : 'en';
@@ -13,6 +13,10 @@ const LicenseStatus = (props: SubscriptionStatusProps): JSX.Element => {
     ? `${OptroBaseUrl}/app/${props.powerupId}`
     : OptroBaseUrl;
   const license = useLicense();
+
+  if (license.inactive) {
+    return <></>;
+  }
 
   if (props.isPro == null && license.errored) {
     return (

--- a/src/components/license-status/LicenseStatus.tsx
+++ b/src/components/license-status/LicenseStatus.tsx
@@ -14,20 +14,21 @@ const LicenseStatus = (props: SubscriptionStatusProps): JSX.Element => {
     : OptroBaseUrl;
   const license = useLicense();
 
-  if(props.isPro == null && license.errored){
+  if (props.isPro == null && license.errored) {
     return (
       <div className="license-display license-display-error">
-        <div className={'information-icon'}>i</div><a href={"https://www.google.com"}>Unable to retrieve license status</a>
+        <div className="information-icon">i</div>
+        <a href="https://www.google.com">Unable to retrieve license status</a>
       </div>
-    )
+    );
   }
 
-  if(props.isPro == null && license.loading){
+  if (props.isPro == null && license.loading) {
     return (
       <div className="license-display license-display-pro">
-        <SimpleLoader colour={"white"}/>
+        <SimpleLoader colour="white" />
       </div>
-    )
+    );
   }
 
   if (props.isPro || (props.isPro == null && license.licensed)) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -13,6 +13,7 @@ export interface LicenseContext {
     powerupId: string;
     licenseType: LicenseType;
     licenseId: string;
+    inactive?: boolean;
 }
 
 export interface LicenseProviderProps {
@@ -30,10 +31,10 @@ export interface TrelloProviderProps {
 }
 
 export interface LicenseConditionalProps {
-    loading?: JSX.Element;
-    licensed?: JSX.Element;
-    unlicensed?: JSX.Element;
-    children?: JSX.Element;
+    loading?: React.ReactElement;
+    licensed?: React.ReactElement;
+    unlicensed?: React.ReactElement;
+    children?: React.ReactElement;
 }
 
 export interface SubscriptionStatusProps {


### PR DESCRIPTION
- Fixes bug where loading true was always returned after a response from optro api
- Adds an inactive flag to the monetisation context
- Updates components to use the inactive flag as an escape clause - The license status component will render nothing and the license conditional will render 'pro' content as preferred with 'free' as fallback if no 'pro' content has been specified.